### PR TITLE
UWP: CoreWindow NULL check

### DIFF
--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -574,7 +574,14 @@ extern "C" {
 	bool uwp_keyboard_pressed(unsigned key)
 	{
 		unsigned sym = rarch_keysym_lut[(enum retro_key)key];
-		return (CoreWindow::GetForCurrentThread()->GetKeyState((VirtualKey)sym) & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down;
+		CoreWindow^ window = CoreWindow::GetForCurrentThread();
+		if (!window)
+		{
+			// At times CoreWindow will return NULL while running Dolphin core
+			// Dolphin core runs on its own CPU thread separate from the UI-thread and so we must do a check for this.
+			return false;
+		}
+		return (window->GetKeyState((VirtualKey)sym) & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down;
 	}
 
 	int16_t uwp_mouse_state(unsigned port, unsigned id, bool screen)


### PR DESCRIPTION
## Description
We need to make sure CoreWindow isn't NULL before checking key states otherwise access violation will occur and cause the app to crash. This PR fixes running Dolphin core in particular and has been tested on both desktop UWP and Xbox One.
